### PR TITLE
feat(api): Add optional systemConfigId parameter to runAndEvaluate()

### DIFF
--- a/examples/create-run-simple.ts
+++ b/examples/create-run-simple.ts
@@ -55,7 +55,7 @@ async function main() {
     metricIds: METRIC_IDS,
     system: runSystem,
   });
-  console.log(`Go to ${run.url} and click "Run Scoring" to grade your Records.`);
+  console.log(`Go to ${run.url} to view your Run's scorecard.`);
 }
 
 main();

--- a/examples/create-run-with-api.ts
+++ b/examples/create-run-with-api.ts
@@ -61,7 +61,7 @@ async function main() {
   }
 
   const runUrl = `https://app.getscorecard.ai/projects/${PROJECT_ID}/runs/grades/${run.id}`;
-  console.log(`Go to ${runUrl} and click "Run Scoring" to grade your Records.`);
+  console.log(`Go to ${runUrl} to view your scorecard.`);
 }
 
 main();

--- a/src/lib/runAndEvaluate.ts
+++ b/src/lib/runAndEvaluate.ts
@@ -7,6 +7,7 @@ import { Scorecard } from '../client';
  * @param projectId The ID of the Project to run the system on.
  * @param testsetId The ID of the Testset to run the system on.
  * @param metricIds The IDs of the Metrics to use for evaluation.
+ * @param systemConfigId The optional ID of the System Configuration to associate with the Run.
  * @param system The system to run on the Testset.
  */
 export async function runAndEvaluate<SystemInput extends Object, SystemOutput extends Object>(
@@ -15,17 +16,24 @@ export async function runAndEvaluate<SystemInput extends Object, SystemOutput ex
     projectId,
     testsetId,
     metricIds,
+    systemConfigId,
     system,
   }: {
     projectId: string;
     testsetId: string;
     metricIds: Array<string>;
+    systemConfigId?: string;
     system: (testcaseInput: SystemInput) => Promise<SystemOutput>;
   },
 ): Promise<Pick<Scorecard.Runs.Run, 'id'> & { url: string }> {
   const run = await scorecard.runs.create(projectId, {
     testsetId,
     metricIds,
+    ...(systemConfigId != null ?
+      {
+        systemConfigId,
+      }
+    : null),
   });
 
   // Run each Testcase sequentially


### PR DESCRIPTION
Adds an optional `systemConfigId` parameter to the `runAndEvaluate` helper.