### PR TITLE
chore(auth): Add backwards compatibility for bearer token auth

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -210,6 +210,8 @@ export class Scorecard {
         "The SCORECARD_API_KEY environment variable is missing or empty; either provide it, or instantiate the Scorecard client with an apiKey option, like new Scorecard({ apiKey: 'My API Key' }).",
       );
     }
+    // Support both API keys (which start with 'ak_') and legacy JWT bearer tokens
+    apiKey = !apiKey || apiKey.startsWith('ak_') ? apiKey : `Bearer ${apiKey}`;
 
     const options: ClientOptions = {
       apiKey,


### PR DESCRIPTION
If the given API key does *not* start with `ak_`, then it's actually a legacy JWT bearer token, which should be sent using this format:

> `Authorization: Bearer <JWT Token>`

instead of

> `Authorization: <API Key>`

, which we use for API key auth.