### PR TITLE
chore: Add server.json for MCP registry

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "scorecard-ai-mcp",
   "version": "2.1.0",
+  "mcpName": "io.scorecard/mcp",
   "description": "The official MCP Server for the Scorecard API",
   "author": "Scorecard <team@scorecard.io>",
   "types": "dist/index.d.ts",

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.scorecard/mcp",
+  "description": "MCP server providing access to the Scorecard API to evaluate and optimize LLM systems.",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/scorecard-ai/scorecard-node",
+    "source": "github"
+  },
+  "version": "2.1.1",
+  "packages": [
+    {
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "scorecard-ai-mcp",
+      "version": "2.1.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environment_variables": [
+        {
+          "description": "Scorecard API key for authentication. Get your API key from https://app.scorecard.io/settings",
+          "is_required": true,
+          "format": "string",
+          "is_secret": true,
+          "name": "SCORECARD_API_KEY"
+        }
+      ]
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.scorecard.io/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Adds `server.json` so that we can add the MCP server (`io.scorecard/mcp`) to the MCP registry following the [instructions here](https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/publish-server.md).

The remote MCP server is at https://mcp.scorecard.io/mcp

I set the `server.json` version to `2.1.1`, because once #22 is released, the version of `scorecard-ai-mcp` will be `2.1.1`.