### PR TITLE
feat(mcp): Use Scorecard API key from MCP client when executing code tool

### DIFF
--- a/packages/mcp-server/src/code-tool.ts
+++ b/packages/mcp-server/src/code-tool.ts
@@ -4,6 +4,7 @@ import { McpTool, Metadata, ToolCallResult, asErrorResult, asTextContentResult }
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { readEnv, readEnvOrError } from './server';
 import { WorkerInput, WorkerOutput } from './code-tool-types';
+import Scorecard from 'scorecard-ai';
 
 const prompt = `Runs JavaScript code to interact with the Scorecard API.
 
@@ -41,7 +42,7 @@ export function codeTool(): McpTool {
     description: prompt,
     inputSchema: { type: 'object', properties: { code: { type: 'string' } } },
   };
-  const handler = async (_: unknown, args: any): Promise<ToolCallResult> => {
+  const handler = async (client: Scorecard, args: any): Promise<ToolCallResult> => {
     const code = args.code as string;
 
     // this is not required, but passing a Stainless API key for the matching project_name
@@ -56,8 +57,8 @@ export function codeTool(): McpTool {
         ...(stainlessAPIKey && { Authorization: stainlessAPIKey }),
         'Content-Type': 'application/json',
         client_envs: JSON.stringify({
-          SCORECARD_API_KEY: readEnvOrError('SCORECARD_API_KEY'),
-          SCORECARD_BASE_URL: readEnv('SCORECARD_BASE_URL'),
+          SCORECARD_API_KEY: client.apiKey || readEnvOrError('SCORECARD_API_KEY'),
+          SCORECARD_BASE_URL: client.baseURL || readEnv('SCORECARD_BASE_URL'),
         }),
       },
       body: JSON.stringify({


### PR DESCRIPTION
The code tool should use the Scorecard API key that we pass in when initializing the MCP server, not the API key in the env variable (unless the initial one doesn't exist).

---

The update to `SCORECARD_API_KEY` is necessary because we have a multi-tenant backend deployment. Our backend creates an MCP server using the _requester's_ API key, not the backend environment's API key.

The update to `SCORECARD_BASE_URL` is because it's convenient to not have to define `SCORECARD_BASE_URL` as an environment variable, since we already pass it into the MCP server when constructing it.