### PR TITLE
feat: add otel_link_id for SDK/trace record deduplication

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,6 @@ export {
   UnprocessableEntityError,
 } from './core/error';
 
-export { runAndEvaluate } from './lib/runAndEvaluate';
+export { runAndEvaluate, type SystemOptions } from './lib/runAndEvaluate';
 export { wrapAISDK } from './lib/wrapAISDK';
 export { wrap, wrapOpenAI, wrapAnthropic } from './lib/wrapLLMs';

--- a/src/lib/runAndEvaluate.ts
+++ b/src/lib/runAndEvaluate.ts
@@ -1,7 +1,20 @@
+import { randomUUID } from 'node:crypto';
 import { Scorecard } from '../client';
 import { Testcase } from '../resources';
 import { ScorecardError } from '../error';
 import { SystemVersion } from '../resources/systems';
+
+/**
+ * Options passed to the system function for each testcase execution.
+ */
+export interface SystemOptions {
+  /**
+   * A unique ID for linking this execution with its OpenTelemetry trace.
+   * Set this as an attribute on your OTel span (e.g. `scorecard.otel_link_id`)
+   * to deduplicate SDK records with trace-created records.
+   */
+  otelLinkId: string;
+}
 
 type RunAndEvaluateArgs<SystemInput extends Record<string, any>, SystemOutput extends Record<string, any>> =
   // Project and metrics are always required
@@ -26,14 +39,18 @@ type RunAndEvaluateArgs<SystemInput extends Record<string, any>, SystemOutput ex
         /**
          * The system function to run on the Testset.
          */
-        system: (testcaseInput: SystemInput, systemVersion: SystemVersion) => Promise<SystemOutput>;
+        system: (
+          testcaseInput: SystemInput,
+          systemVersion: SystemVersion,
+          options: SystemOptions,
+        ) => Promise<SystemOutput>;
       }
     // Otherwise, the system function receives only the testcase input
     | {
         /**
          * The system function to run on the Testset.
          */
-        system: (testcaseInput: SystemInput) => Promise<SystemOutput>;
+        system: (testcaseInput: SystemInput, options: SystemOptions) => Promise<SystemOutput>;
       }
   ) &
     // If testset is not provided, you must pass in all the testcases manually
@@ -149,14 +166,19 @@ export async function runAndEvaluate<
 
   for await (const { testcaseId, inputs, expected } of testcaseIterator(scorecard, args)) {
     for (let i = 0; i < trials; i++) {
-      const modelResponsePromise =
-        hasSystemVersion ? args.system(inputs, systemVersion!) : args.system(inputs);
+      const otelLinkId = randomUUID();
+      const systemOptions: SystemOptions = { otelLinkId };
+
+      const modelResponsePromise = hasSystemVersion
+        ? args.system(inputs, systemVersion!, systemOptions)
+        : args.system(inputs, systemOptions);
 
       function createRecord(outputs: SystemOutput): Promise<unknown> {
         return scorecard.records.create(run.id, {
           inputs,
           expected,
           outputs,
+          otelLinkId,
           ...(testcaseId != null ? { testcaseId } : null),
         });
       }

--- a/src/lib/runAndEvaluate.ts
+++ b/src/lib/runAndEvaluate.ts
@@ -177,14 +177,14 @@ export async function runAndEvaluate<
       const systemOptions: SystemOptions = { otelLinkId };
 
       let modelResponsePromise: Promise<SystemOutput>;
-      if (hasSystemVersion) {
-        modelResponsePromise = acceptsOptions
-          ? args.system(inputs, systemVersion!, systemOptions)
-          : args.system(inputs, systemVersion!);
+      if (hasSystemVersion && acceptsOptions) {
+        modelResponsePromise = args.system(inputs, systemVersion!, systemOptions);
+      } else if (hasSystemVersion) {
+        modelResponsePromise = args.system(inputs, systemVersion!);
+      } else if (acceptsOptions) {
+        modelResponsePromise = args.system(inputs, systemOptions);
       } else {
-        modelResponsePromise = acceptsOptions
-          ? args.system(inputs, systemOptions)
-          : args.system(inputs);
+        modelResponsePromise = args.system(inputs);
       }
 
       function createRecord(outputs: SystemOutput): Promise<unknown> {

--- a/src/lib/runAndEvaluate.ts
+++ b/src/lib/runAndEvaluate.ts
@@ -176,13 +176,16 @@ export async function runAndEvaluate<
       const otelLinkId = randomUUID();
       const systemOptions: SystemOptions = { otelLinkId };
 
-      const modelResponsePromise = hasSystemVersion
-        ? acceptsOptions
+      let modelResponsePromise: Promise<SystemOutput>;
+      if (hasSystemVersion) {
+        modelResponsePromise = acceptsOptions
           ? args.system(inputs, systemVersion!, systemOptions)
-          : args.system(inputs, systemVersion!)
-        : acceptsOptions
+          : args.system(inputs, systemVersion!);
+      } else {
+        modelResponsePromise = acceptsOptions
           ? args.system(inputs, systemOptions)
           : args.system(inputs);
+      }
 
       function createRecord(outputs: SystemOutput): Promise<unknown> {
         return scorecard.records.create(run.id, {

--- a/src/lib/runAndEvaluate.ts
+++ b/src/lib/runAndEvaluate.ts
@@ -38,19 +38,21 @@ type RunAndEvaluateArgs<SystemInput extends Record<string, any>, SystemOutput ex
 
         /**
          * The system function to run on the Testset.
+         * Optionally accepts a SystemOptions argument containing `otelLinkId` for trace deduplication.
          */
         system: (
           testcaseInput: SystemInput,
           systemVersion: SystemVersion,
-          options: SystemOptions,
+          options?: SystemOptions,
         ) => Promise<SystemOutput>;
       }
     // Otherwise, the system function receives only the testcase input
     | {
         /**
          * The system function to run on the Testset.
+         * Optionally accepts a SystemOptions argument containing `otelLinkId` for trace deduplication.
          */
-        system: (testcaseInput: SystemInput, options: SystemOptions) => Promise<SystemOutput>;
+        system: (testcaseInput: SystemInput, options?: SystemOptions) => Promise<SystemOutput>;
       }
   ) &
     // If testset is not provided, you must pass in all the testcases manually
@@ -164,14 +166,23 @@ export async function runAndEvaluate<
 
   const recordPromises: Array<Promise<unknown>> = [];
 
+  // Detect whether the system function accepts the options argument.
+  // With systemVersion: (input, systemVersion, options?) — 3 args means it accepts options
+  // Without systemVersion: (input, options?) — 2 args means it accepts options
+  const acceptsOptions = hasSystemVersion ? args.system.length >= 3 : args.system.length >= 2;
+
   for await (const { testcaseId, inputs, expected } of testcaseIterator(scorecard, args)) {
     for (let i = 0; i < trials; i++) {
       const otelLinkId = randomUUID();
       const systemOptions: SystemOptions = { otelLinkId };
 
       const modelResponsePromise = hasSystemVersion
-        ? args.system(inputs, systemVersion!, systemOptions)
-        : args.system(inputs, systemOptions);
+        ? acceptsOptions
+          ? args.system(inputs, systemVersion!, systemOptions)
+          : args.system(inputs, systemVersion!)
+        : acceptsOptions
+          ? args.system(inputs, systemOptions)
+          : args.system(inputs);
 
       function createRecord(outputs: SystemOutput): Promise<unknown> {
         return scorecard.records.create(run.id, {

--- a/src/resources/records.ts
+++ b/src/resources/records.ts
@@ -138,6 +138,12 @@ export interface RecordCreateParams {
   outputs: { [key: string]: unknown };
 
   /**
+   * Optional ID for linking this record with an OpenTelemetry trace. Used for
+   * deduplication.
+   */
+  otelLinkId?: string;
+
+  /**
    * The ID of the Testcase.
    */
   testcaseId?: string;


### PR DESCRIPTION
Add `otel_link_id` support to `runAndEvaluate` for deduplicating records created by both the SDK and the OTel trace processing pipeline.

## Summary

- Generate a unique `otelLinkId` (UUID) per testcase execution in `runAndEvaluate`
- Pass it to the user's system function via a new `SystemOptions` parameter
- Include it in the `createRecord` API call
- Export `SystemOptions` type from package root

## Breaking change

The system function signature now includes `SystemOptions` as the last argument:

```typescript
// Before (without system version):
system: (input: SystemInput) => Promise<SystemOutput>
// After:
system: (input: SystemInput, options: SystemOptions) => Promise<SystemOutput>

// Before (with system version):
system: (input: SystemInput, systemVersion: SystemVersion) => Promise<SystemOutput>
// After:
system: (input: SystemInput, systemVersion: SystemVersion, options: SystemOptions) => Promise<SystemOutput>
```

Users should set `scorecard.otel_link_id` as an OTel span attribute in their system function to enable deduplication.

## Companion PRs

- Backend: scorecard-ai/scorecard#552, scorecard-ai/scorecard#553
- Python SDK: scorecard-ai/scorecard-python#TBD

## Test plan

- E2E tested locally with full OTel pipeline (gateway → collector → ClickHouse → Temporal) — single merged record confirmed