### PR TITLE
Add npm homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "main": "dist/index.js",
   "type": "commonjs",
   "repository": "github:scorecard-ai/scorecard-node",
+  "homepage": "https://github.com/scorecard-ai/scorecard-node#readme",
+  "bugs": {
+    "url": "https://github.com/scorecard-ai/scorecard-node/issues"
+  },
   "license": "Apache-2.0",
   "packageManager": "yarn@1.22.22",
   "files": [


### PR DESCRIPTION
## Summary
- Add the package README as the npm homepage.
- Add the public GitHub issues URL as the npm bugs metadata.

## Verification
- npm view scorecard-ai@3.1.0 name version homepage repository bugs --json
- node metadata smoke for homepage, bugs.url, and unchanged repository
- npm pack --dry-run --ignore-scripts
- git diff --check