### PR TITLE
fix(examples): update retired claude-3-haiku model

### DIFF
--- a/examples/anthropic-simple.ts
+++ b/examples/anthropic-simple.ts
@@ -9,7 +9,7 @@ const claude = wrap(
 
 async function main() {
   const response = await claude.messages.create({
-    model: 'claude-3-haiku-20240307',
+    model: 'claude-haiku-4-5-20251001',
     max_tokens: 500,
     messages: [{ role: 'user', content: 'What is the capital of France?' }],
   });

--- a/examples/anthropic-streaming.ts
+++ b/examples/anthropic-streaming.ts
@@ -12,7 +12,7 @@ async function main() {
 
   // Create a streaming request
   const stream = await claude.messages.stream({
-    model: 'claude-3-haiku-20240307',
+    model: 'claude-haiku-4-5-20251001',
     messages: [{ role: 'user', content: 'Write a short poem about TypeScript programming.' }],
     temperature: 0.7,
     max_tokens: 200,

--- a/examples/nested-advanced.ts
+++ b/examples/nested-advanced.ts
@@ -54,7 +54,7 @@ async function analyzeWithMultipleLLMs(userQuery: string) {
           claudeSpan.setAttribute('llm.provider', 'anthropic');
 
           const response = await claude.messages.create({
-            model: 'claude-3-haiku-20240307',
+            model: 'claude-haiku-4-5-20251001',
             max_tokens: 200,
             messages: [
               {


### PR DESCRIPTION
## Summary

The Anthropic examples hardcode `claude-3-haiku-20240307`, which Anthropic has **retired**. Running them today returns a `404 not_found_error`, so the examples are broken for anyone who tries them.

This updates the three references to the current `claude-haiku-4-5-20251001` snapshot.

## Files

- `examples/anthropic-simple.ts`
- `examples/anthropic-streaming.ts`
- `examples/nested-advanced.ts`

## Verification

While validating the 3.2.0 release I ran every example against a live Scorecard project. These three failed only on the retired model; swapping in `claude-haiku-4-5-20251001` made all three pass end-to-end (request succeeds + traces export through `wrapAnthropic` and the nested-trace path). All other examples already pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)